### PR TITLE
添加 speedcopy 支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ mcd_root/
 
 默认值: `False`
 
-使用 `speedcopy` 加速 Windows 共享 的传输速度。需要 [speedcopy](https://pypi.org/project/speedcopy/) 包。更多技术细节请参考此包的 README。
+使用 `speedcopy` 加速传输速度。需要 [speedcopy](https://pypi.org/project/speedcopy/) 包。更多技术细节请参考此包的 README。
 
 ### world_names
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ mcd_root/
 
 被覆盖的存档的备份位置，在配置文件均为默认值的情况下路径为 `./qb_multi/overwrite`
 
+### use_speedcopy
+
+默认值: `False`
+
+使用 `speedcopy` 加速 Windows 共享 的传输速度。需要 [speedcopy](https://pypi.org/project/speedcopy/) 包。更多技术细节请参考此包的 README。
+
 ### world_names
 
 默认值:

--- a/README_en.md
+++ b/README_en.md
@@ -143,7 +143,7 @@ The backup position of the overwritten world. With default config file the path 
 
 Default: `False`
 
-Use `speedcopy` to accelerate transfer on windows shares. Need [speedcopy](https://pypi.org/project/speedcopy/) package. Refer to the package description to see more details.
+Use `speedcopy` to accelerate transfer. Need [speedcopy](https://pypi.org/project/speedcopy/) package. Refer to the package description to see more details.
 
 ### WorldNames
 

--- a/README_en.md
+++ b/README_en.md
@@ -139,6 +139,12 @@ Default: `overwrite`
 
 The backup position of the overwritten world. With default config file the path will be `./qb_multi/overwrite`
 
+### use_speedcopy
+
+Default: `False`
+
+Use `speedcopy` to accelerate transfer on windows shares. Need [speedcopy](https://pypi.org/project/speedcopy/) package. Refer to the package description to see more details.
+
 ### WorldNames
 
 Default:

--- a/quick_backup_multi/__init__.py
+++ b/quick_backup_multi/__init__.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import time
+from importlib import import_module
 from threading import Lock
 from typing import Optional, Any
 
@@ -500,6 +501,17 @@ def load_config(server: ServerInterface, source: CommandSource or None = None):
 		elif not last <= this:
 			server.logger.warning('Slot {} has a delete protection time smaller than the former one'.format(i + 1))
 		last = this
+	load_speedcopy(server)
+
+def load_speedcopy(server: ServerInterface):
+	if config.use_speedcopy:
+		try:
+			import_module('speedcopy').patch_copyfile()
+		except ModuleNotFoundError:
+			server.logger.warning('Speedcopy module not found. Using original copyfile method.')
+	elif hasattr(shutil, '_orig_copyfile'):
+		shutil.copyfile = shutil._orig_copyfile
+		delattr(shutil, '_orig_copyfile')
 
 
 def register_event_listeners(server: PluginServerInterface):

--- a/quick_backup_multi/__init__.py
+++ b/quick_backup_multi/__init__.py
@@ -504,14 +504,18 @@ def load_config(server: ServerInterface, source: CommandSource or None = None):
 	load_speedcopy(server)
 
 def load_speedcopy(server: ServerInterface):
-	if config.use_speedcopy:
-		try:
-			import_module('speedcopy').patch_copyfile()
-		except ModuleNotFoundError:
-			server.logger.warning('Speedcopy module not found. Using original copyfile method.')
-	elif hasattr(shutil, '_orig_copyfile'):
-		shutil.copyfile = shutil._orig_copyfile
-		delattr(shutil, '_orig_copyfile')
+	try:
+		speedcopy = import_module('speedcopy')
+		speedcopy.unpatch_copyfile()
+	except ModuleNotFoundError:
+		speedcopy = None
+	except AttributeError:
+		pass
+	if config.use_speedcopy and speedcopy is not None:
+			speedcopy.patch_copyfile()
+			server.logger.info('Using speedcopy as copyfile method.')
+	else:
+		server.logger.info('Using original shutil.copyfile as copyfile method.')
 
 
 def register_event_listeners(server: PluginServerInterface):

--- a/quick_backup_multi/config.py
+++ b/quick_backup_multi/config.py
@@ -16,6 +16,7 @@ class Configure(Serializable):
 	backup_path: str = './qb_multi'
 	server_path: str = './server'
 	overwrite_backup_folder: str = 'overwrite'
+	use_speedcopy: bool = False
 	world_names: List[str] = [
 		'world'
 	]


### PR DESCRIPTION
## ❓ 为什么

speedcopy 包的描述如下：

```plain
Patched python shutil.copyfile using native call CopyFile2 on windows to accelerate transfer on windows shares.
On Linux, it issues special ioctl command CIFS_IOC_COPYCHUNK_FILE to enable server-side copy.
```

看起来是对 NAS 用户有帮助，但似乎本地存储的传输速度也有提高

## 🔨 实现

加载配置时给 shutil.copyfile 打补丁（

## ⚠️ 注意

未修改版本号（