### PR TITLE
"使用tar和tar.gz格式备份，显示备份失败" bug修复

### DIFF
--- a/quick_backup_multi/__init__.py
+++ b/quick_backup_multi/__init__.py
@@ -163,7 +163,7 @@ def copy_worlds(src: str, dst: str, intent: CopyWorldIntent, *, backup_format: O
 					server_inst.logger.info('storing {} -> {}'.format(src_path, tar_path))
 					if os.path.exists(src_path):
 						def tar_filter(info: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
-							if config.is_file_ignored(info.name):
+							if config.is_file_ignored(info.name.removeprefix(world + "/")):
 								return None
 							return info
 						backup_file.add(src_path, arcname=world, filter=tar_filter)


### PR DESCRIPTION
#41 添加了适应tarfile的TarInfo格式的字符串处理，windows经测试运行正常